### PR TITLE
fix func_call execution f-string

### DIFF
--- a/model_inference/multi_turn/multi_turn_utils.py
+++ b/model_inference/multi_turn/multi_turn_utils.py
@@ -90,7 +90,7 @@ def execute_agent_func_call(
                 func_call_result = eval(func_call)
             execution_results.append(func_call_result)
         except Exception as e:
-            errors = "Error during execution: {str(e)}"
+            errors = f"Error during execution: {str(e)}"
             return errors, involved_classes
 
     for index in range(len(execution_results)):


### PR DESCRIPTION
```python
for func_call in func_call_list:
    # Add the instance name to the method calls
    func_calls = _process_method_calls(func_call, class_method_name_mapping)
        
    try:
        for func_call in func_calls:
            func_call_result = eval(func_call)
        execution_results.append(func_call_result)
    except Exception as e:
        errors = "Error during execution: {str(e)}" # should be a f-string
        return errors, involved_classes
```

there's a missing `f` prefix on the `errors` string. this is true only for the `multi-turn` variant 